### PR TITLE
remove curly bracket

### DIFF
--- a/run.md
+++ b/run.md
@@ -3,7 +3,7 @@
 
 ```Ruby
 puts "start"
-EM.run do {
+EM.run do
   puts "Init"
   EM.add_timer(1) do
     puts "Quit"


### PR DESCRIPTION
Maybe it's easier for beginner to follow if adding the following code at the top.
require 'eventmachine'
